### PR TITLE
Broken links in README.md files

### DIFF
--- a/dept-news/README.md
+++ b/dept-news/README.md
@@ -1,6 +1,6 @@
 # Dept News Format
 
-Based on the dept-news template published by the Typst team at <https://typst/typst-templates/dept-news>.
+Based on the dept-news template published by the Typst team at <https://github.com/typst/templates/blob/main/dept-news>.
 
 **NOTE**: This format requires the pre-release version of Quarto v1.4, which you can download here: <https://quarto.org/docs/download/prerelease>.
 

--- a/dept-news/README.md
+++ b/dept-news/README.md
@@ -1,6 +1,6 @@
 # Dept News Format
 
-Based on the dept-news template published by the Typst team at <https://github.com/typst/templates/blob/main/dept-news>.
+Based on the dept-news template published by the Typst team at <https://github.com/typst/templates/tree/main/dept-news>.
 
 **NOTE**: This format requires the pre-release version of Quarto v1.4, which you can download here: <https://quarto.org/docs/download/prerelease>.
 

--- a/fiction/README.md
+++ b/fiction/README.md
@@ -1,6 +1,6 @@
 # Typst Fiction Format
 
-Based on the fiction template published by the Typst team at <https://typst/typst-templates/fiction>.
+Based on the fiction template published by the Typst team at <https://github.com/typst/templates/tree/main/fiction>.
 
 **NOTE**: This format requires the pre-release version of Quarto v1.4, which you can download here: <https://quarto.org/docs/download/prerelease>.
 

--- a/ieee/README.md
+++ b/ieee/README.md
@@ -1,6 +1,6 @@
 # Typst IEEE Format
 
-Based on the IEE template published by the Typst team at <https://typst/typst-templates/ieee>.
+Based on the IEE template published by the Typst team at <https://github.com/typst/templates/tree/main/ieee>.
 
 **NOTE**: This format requires the pre-release version of Quarto v1.4, which you can download here: <https://quarto.org/docs/download/prerelease>.
 

--- a/letter/README.md
+++ b/letter/README.md
@@ -1,6 +1,6 @@
 # Typst Letter Format
 
-Based on tbe letter template published by the Typst team at <https://typst/typst-templates/letter>.
+Based on tbe letter template published by the Typst team at <https://github.com/typst/templates/tree/main/letter>.
 
 **NOTE**: This format requires the pre-release version of Quarto v1.4, which you can download here: <https://quarto.org/docs/download/prerelease>.
 


### PR DESCRIPTION
Some links to the typst templates appears to be relative (?) but do not dereference correctly when used from the GitHub web ui. This change changes those links to be absolute. Suggest using squash+merge when/if merging.